### PR TITLE
Add Facebook Ads video transcriber integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.apify/
+*.log
+*.env

--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -1,0 +1,106 @@
+{
+  "title": "Facebook Ads Video Transcriber Integration Input",
+  "type": "object",
+  "schemaVersion": 1,
+  "properties": {
+    "facebookAdsInput": {
+      "title": "Facebook Ads Scraper Input",
+      "type": "object",
+      "description": "Parameters passed directly to the Facebook Ads Scraper actor.",
+      "properties": {
+        "searchTerm": {
+          "title": "Search term or Page ID",
+          "type": "string",
+          "description": "Keyword or page identifier to search for.",
+          "editor": "textfield"
+        },
+        "searchType": {
+          "title": "Search type",
+          "type": "string",
+          "enum": ["keyword", "page"],
+          "default": "keyword",
+          "description": "Defines whether 'searchTerm' is a keyword or a page ID."
+        },
+        "adReachedCountries": {
+          "title": "Ad reached countries",
+          "type": "array",
+          "description": "ISO country codes for the audience location.",
+          "editor": "textfield",
+          "items": {"type": "string"}
+        },
+        "publisherPlatforms": {
+          "title": "Publisher platforms",
+          "type": "array",
+          "description": "Platforms where the ads were served (e.g., facebook, instagram).",
+          "items": {"type": "string"}
+        },
+        "languages": {
+          "title": "Ad languages",
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Languages of the ads."
+        },
+        "maxAds": {
+          "title": "Max ads",
+          "type": "integer",
+          "default": 50,
+          "description": "Maximum number of ads to scrape."
+        }
+      },
+      "additionalProperties": true
+    },
+    "openaiApiKey": {
+      "title": "OpenAI API Key",
+      "type": "string",
+      "editor": "textfield",
+      "description": "API key for the OpenAI transcription service.",
+      "prefill": "",
+      "pattern": ".*",
+      "secret": true,
+      "minLength": 1
+    },
+    "openaiModel": {
+      "title": "OpenAI Model",
+      "type": "string",
+      "enum": ["gpt-4o-mini-transcribe", "whisper-1"],
+      "default": "gpt-4o-mini-transcribe"
+    },
+    "openaiTranscriptionLanguage": {
+      "title": "Transcription language",
+      "type": "string",
+      "default": "es",
+      "description": "Language used for transcription of the audio content."
+    },
+    "openaiTranscriptionPrompt": {
+      "title": "Transcription prompt",
+      "type": "string",
+      "description": "Optional prompt sent to the transcriber actor.",
+      "editor": "textfield"
+    },
+    "openaiTranscriptionTemperature": {
+      "title": "Transcription temperature",
+      "type": "string",
+      "default": "0.0",
+      "description": "OpenAI temperature parameter for transcription."
+    },
+    "transcriberMaxConcurrentTasks": {
+      "title": "Transcriber max concurrent tasks",
+      "type": "integer",
+      "default": 5,
+      "description": "Maximum number of concurrent tasks for the transcriber actor."
+    },
+    "transcriberMaxRetries": {
+      "title": "Transcriber max retries",
+      "type": "integer",
+      "default": 3,
+      "description": "Maximum number of retries for the transcriber actor."
+    },
+    "maxVideoUrlsPerAd": {
+      "title": "Max video URLs per ad",
+      "type": "integer",
+      "default": 1,
+      "description": "Limits the number of video URLs extracted and sent for transcription from each individual Facebook Ad entry. Set to 0 for no limit (all videos will be processed)."
+    }
+  },
+  "required": ["facebookAdsInput", "openaiApiKey"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,90 @@
-# fb-ads-transcriber
+# Facebook Ads Video Transcriber Integration (Concise Metadata)
+
+This Apify Actor scrapes Facebook video ads, extracts their audio, transcribes it using OpenAI, and saves the transcription along with selected key metadata for streamlined analysis.
+
+## Features
+
+- **Combines scraping and transcription** of Facebook video ads
+- **Extracts specific ad metadata** only
+- **Configurable ad search and video selection**
+- **OpenAI powered** transcription
+- **Robust error handling**
+- **Concurrent processing** of video tasks
+- **Flexible video URL extraction** with limits
+
+## How it Works
+
+1. Scrapes Facebook Ads using the Facebook Ads Scraper actor.
+2. Extracts video URLs and essential details from each ad.
+3. Sends videos to the Audio and Video Transcriber actor.
+4. Combines transcription results with the selected ad metadata and outputs them.
+
+## Input Configuration
+
+See [`INPUT_SCHEMA.json`](INPUT_SCHEMA.json) for the complete schema. Important parameters include:
+
+- **facebookAdsInput** – Object passed directly to the Facebook Ads Scraper actor.
+- **openaiApiKey** *(required)* – Your OpenAI API key.
+- **openaiModel** – Model used for transcription (`gpt-4o-mini-transcribe` or `whisper-1`).
+- **openaiTranscriptionLanguage** – Language of the ads' audio. Default is `es`.
+- **openaiTranscriptionPrompt** – Optional prompt for the transcription.
+- **openaiTranscriptionTemperature** – Temperature for OpenAI transcription requests.
+- **transcriberMaxConcurrentTasks** – Concurrency for the transcriber actor.
+- **transcriberMaxRetries** – Retry count for the transcriber actor.
+- **maxVideoUrlsPerAd** – Number of video URLs extracted from each ad (0 = no limit).
+
+## Output Structure
+
+The actor stores each processed ad in the default dataset with the following JSON structure:
+
+```json
+{
+  "page_name": "String | Null",
+  "Company_Name": "String | Null",
+  "Website": "String | Null",
+  "caption": "String | Null",
+  "cta_text": "String | Null",
+  "cta_type": "String | Null",
+  "title": "String | Null",
+  "body": "String | Null",
+  "download_url": "String | Null",
+  "transcription": "String | Null",
+  "status": "String",
+  "error_message": "String | Null"
+}
+```
+
+**Field descriptions**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `page_name` | String\|Null | Name of the Facebook page posting the ad. |
+| `Company_Name` | String\|Null | Company name associated with the ad (if available). |
+| `Website` | String\|Null | Website link from the ad details. |
+| `caption` | String\|Null | Caption text from the ad snapshot. |
+| `cta_text` | String\|Null | Call to action text. |
+| `cta_type` | String\|Null | Call to action type. |
+| `title` | String\|Null | Ad title. |
+| `body` | String\|Null | Ad body text. |
+| `download_url` | String\|Null | Video URL that was transcribed. |
+| `transcription` | String\|Null | Transcribed text from the video. |
+| `status` | String | Result of the transcription (`succeeded`, `failed`, `no_video_found`, `transcription_actor_no_output`, `transcription_failed`). |
+| `error_message` | String\|Null | Error details if transcription failed. |
+
+## Setup / Deployment on Apify
+
+1. Create a new actor on Apify and upload the files from this repository.
+2. **Important:** Open `main.js` and replace the placeholder `FACEBOOK_ADS_SCRAPER_ACTOR_ID` and `VIDEO_TRANSCRIBER_ACTOR_ID` with your actual Apify Actor IDs.
+3. Build the actor on the Apify platform.
+4. Run the actor with your desired input parameters.
+
+## Important Notes / Limitations
+
+- The OpenAI API key is sensitive and subject to rate limits and quotas.
+- Video URLs may expire over time; transcription should be run soon after scraping.
+- `maxVideoUrlsPerAd` controls how many videos from each ad are processed (0 processes all).
+
+## Support / Contact
+
+This template is provided as-is. For issues or questions, please reach out via your usual Apify support channels or open an issue in your repository.
+

--- a/apify.json
+++ b/apify.json
@@ -1,0 +1,9 @@
+{
+  "name": "fb-ads-video-transcriber-integration",
+  "version": "0.0.1",
+  "buildTag": "latest",
+  "env": {
+    "APIFY_MEMORY_MBYTES": 2048,
+    "APIFY_TIMEOUT_SECS": 3600
+  }
+}

--- a/main.js
+++ b/main.js
@@ -1,0 +1,142 @@
+const Apify = require('apify');
+
+// TODO: Replace the placeholder IDs with your actual actor IDs
+const FACEBOOK_ADS_SCRAPER_ACTOR_ID = 'USERNAME/ACTOR_ID_FOR_FACEBOOK_ADS_SCRAPER';
+const VIDEO_TRANSCRIBER_ACTOR_ID = 'USERNAME/ACTOR_ID_FOR_VIDEO_TRANSCRIBER';
+
+Apify.main(async () => {
+    const input = await Apify.getInput() || {};
+    const {
+        facebookAdsInput = {},
+        openaiApiKey,
+        openaiModel = 'gpt-4o-mini-transcribe',
+        openaiTranscriptionLanguage = 'es',
+        openaiTranscriptionPrompt,
+        openaiTranscriptionTemperature = '0.0',
+        transcriberMaxConcurrentTasks = 5,
+        transcriberMaxRetries = 3,
+        maxVideoUrlsPerAd = 1,
+    } = input;
+
+    if (!openaiApiKey) {
+        throw new Error('Input "openaiApiKey" is required.');
+    }
+
+    // Step 1: Run Facebook Ads Scraper
+    const fbRun = await Apify.call(FACEBOOK_ADS_SCRAPER_ACTOR_ID, facebookAdsInput);
+    const fbDataset = await Apify.openDataset(fbRun.defaultDatasetId);
+
+    const requestQueue = await Apify.openRequestQueue();
+
+    await fbDataset.forEach(async ({ item }) => {
+        const metadata = extractMetadata(item);
+        const snapshot = item.snapshot || {};
+        const videoUrls = extractVideoUrls(snapshot, maxVideoUrlsPerAd);
+
+        if (videoUrls.length === 0) {
+            await Apify.pushData({
+                ...metadata,
+                download_url: null,
+                transcription: null,
+                status: 'no_video_found',
+                error_message: null,
+            });
+            return;
+        }
+
+        for (const videoUrl of videoUrls) {
+            await requestQueue.addRequest({
+                url: videoUrl,
+                userData: { metadata, videoUrl },
+            });
+        }
+    });
+
+    const crawler = new Apify.BasicCrawler({
+        requestQueue,
+        maxConcurrency: 5,
+        maxRequestsPerMinute: 10,
+        handleRequestFunction: async ({ request }) => {
+            const { metadata, videoUrl } = request.userData;
+            try {
+                const run = await Apify.call(VIDEO_TRANSCRIBER_ACTOR_ID, {
+                    video_urls: [videoUrl],
+                    openai_api_key: openaiApiKey,
+                    openai_model: openaiModel,
+                    openai_transcription_language: openaiTranscriptionLanguage,
+                    openai_transcription_prompt: openaiTranscriptionPrompt,
+                    openai_transcription_temperature: openaiTranscriptionTemperature,
+                    max_concurrent_tasks: transcriberMaxConcurrentTasks,
+                    max_retries: transcriberMaxRetries,
+                });
+                const ds = await Apify.openDataset(run.defaultDatasetId);
+                const { items } = await ds.getData({ limit: 1 });
+                if (items.length) {
+                    const { transcription = null, download_url = videoUrl, status = 'succeeded', error_message = null } = items[0];
+                    await Apify.pushData({ ...metadata, download_url, transcription, status, error_message });
+                } else {
+                    await Apify.pushData({ ...metadata, download_url: videoUrl, transcription: null, status: 'transcription_actor_no_output', error_message: null });
+                }
+            } catch (err) {
+                await Apify.pushData({ ...metadata, download_url: videoUrl, transcription: null, status: 'transcription_failed', error_message: err.message });
+            }
+        },
+    });
+
+    await crawler.run();
+});
+
+function extractMetadata(item) {
+    const snapshot = item.snapshot || {};
+    const firstCard = Array.isArray(snapshot.cards) && snapshot.cards[0] ? snapshot.cards[0] : {};
+    return {
+        page_name: item.page_name || null,
+        Company_Name: item['Company Name'] || null,
+        Website: item.Website || null,
+        caption: snapshot.caption || null,
+        cta_text: (firstCard.cta_text || snapshot.cta_text) || null,
+        cta_type: (firstCard.cta_type || snapshot.cta_type) || null,
+        title: (firstCard.title || snapshot.title) || null,
+        body: ((firstCard.body && firstCard.body.text) || (snapshot.body && snapshot.body.text)) || null,
+    };
+}
+
+function extractVideoUrls(snapshot, limit) {
+    const urls = [];
+    if (!snapshot) return urls;
+
+    const addUrl = (url) => {
+        if (!url) return;
+        if (/^https?:\/\//i.test(url) && !urls.includes(url)) {
+            urls.push(url);
+        }
+    };
+
+    const maybeAdd = (video) => {
+        if (!video) return;
+        addUrl(video.video_sd_url || video.video_hd_url || video.original_video_url);
+    };
+
+    if (Array.isArray(snapshot.videos)) {
+        for (const vid of snapshot.videos) {
+            maybeAdd(vid);
+            if (limit > 0 && urls.length >= limit) return urls;
+        }
+    }
+
+    if (Array.isArray(snapshot.extra_videos) && (limit === 0 || urls.length < limit)) {
+        for (const vid of snapshot.extra_videos) {
+            maybeAdd(vid);
+            if (limit > 0 && urls.length >= limit) return urls;
+        }
+    }
+
+    if (Array.isArray(snapshot.cards) && (limit === 0 || urls.length < limit)) {
+        for (const card of snapshot.cards) {
+            addUrl(card.video_sd_url || card.video_hd_url);
+            if (limit > 0 && urls.length >= limit) return urls;
+        }
+    }
+
+    return urls;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fb-ads-video-transcriber-integration",
+  "version": "0.0.1",
+  "main": "main.js",
+  "scripts": {
+    "start": "node main.js"
+  },
+  "dependencies": {
+    "apify": "^3.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up actor configuration in `apify.json`
- define full input schema with OpenAI and Facebook Ads settings
- implement integration logic in `main.js`
- document usage and limitations in `README.md`
- add project metadata and `.gitignore`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e54ee76ac832fbd3ff3d842d6a865